### PR TITLE
Fix for AGP 8+

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,8 +30,13 @@ android {
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }
+    
     defaultConfig {
         minSdkVersion 16
+    }
+    
+    if (project.android.hasProperty("namespace")) {
+        namespace 'id.co.eyro.image_compression_flutter'
     }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,6 +38,15 @@ android {
     if (project.android.hasProperty("namespace")) {
         namespace 'id.co.eyro.image_compression_flutter'
     }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11  // Updated from VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+
+    kotlinOptions {
+        jvmTarget = "11"  // Updated from VERSION_1_8
+    }
 }
 
 dependencies {


### PR DESCRIPTION
Dear @alann-maulana 
I hope you are well.

Here is a fix for the [https://github.com/alann-maulana/image_compression_flutter/issues/15](issue).

- I've added namespace to build.gradle by applying recommendation of @Sameri11.
- Changed kotlinOptions and compileOptions to Use Java Version 11.

Thanks in advance.